### PR TITLE
Make adasockets build reproducibly

### DIFF
--- a/src/Makefile.RTEMS
+++ b/src/Makefile.RTEMS
@@ -55,10 +55,10 @@ sockets-link.ads: sockets-link.ads.in Makefile.RTEMS
 	    -e '/@RESOLVNEEDED@/d' $< >$@
 
 sockets-thin.ads: sockets-thin.ads.unix
-	cp $< $@
+	cp -p $< $@
 
 sockets-constants.ads: ../rtems/sockets-constants.ads
-	cp $< $@
+	cp -p $< $@
 
 $(ADB_OBJ): %.o: %.adb
 	$(CC) $(CPU_CFLAGS) $(CFLAGS)-c $<

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -73,11 +73,11 @@ nodist_libadasockets_la_SOURCES += \
 ADA_OBJECTS +=	sockets-windows_link.o
 
 sockets-thin.ads: $(srcdir)/sockets-thin.ads.win32
-	cp $(srcdir)/sockets-thin.ads.win32 sockets-thin.ads
-	cp $(srcdir)/sockets-thin.adb.win32 sockets-thin.adb
+	cp -p $(srcdir)/sockets-thin.ads.win32 sockets-thin.ads
+	cp -p $(srcdir)/sockets-thin.adb.win32 sockets-thin.adb
 else
 sockets-thin.ads: $(srcdir)/sockets-thin.ads.unix
-	cp -f $(srcdir)/sockets-thin.ads.unix sockets-thin.ads
+	cp -p -f $(srcdir)/sockets-thin.ads.unix sockets-thin.ads
 endif
 
 SUFFIXES = .ads .lo .ali

--- a/src/constants.sh
+++ b/src/constants.sh
@@ -54,11 +54,7 @@ trap "rm -f ${tmpe}" 0 1 2 3 15
 # Header of generated file
 
 cat > ${fname} << EOF
---  This package has been generated automatically on:
-EOF
-./split "`uname -a`" >> ${fname}
-echo "--  Generation date: `date`" >> ${fname}
-cat >> ${fname} << EOF
+--  This package has been generated automatically.
 --  Any change you make here is likely to be lost !
 package ${name} is
 EOF


### PR DESCRIPTION
Hi!

I'm working on the [Reproducible Builds](https://wiki.debian.org/ReproducibleBuilds) project in Debian, which is trying to make it possible to rebuild every package in Debian reproducibly. Once complete, reproducible builds will let users independently verify that a binary package corresponds to its purported source and hasn't been surreptitiously modified.

We discovered that adasockets isn't reproducible, because the build time and output of uname are captured during the build process.  Would you be willing to apply these two commits to remove the non-deterministic information and allow adasockets to build reproducibly?

Thanks!
Andrew
