### PR TITLE
fix compilation

### DIFF
--- a/src/sockets-multicast.adb
+++ b/src/sockets-multicast.adb
@@ -38,13 +38,13 @@
 
 with Ada.Exceptions;    use Ada.Exceptions;
 with Interfaces.C;      use Interfaces.C;
-with Sockets;
-pragma Elaborate_All (Sockets);
 with Sockets.Constants; use Sockets.Constants;
 with Sockets.Naming;    use Sockets.Naming;
 with Sockets.Thin;      use Sockets.Thin;
 with Sockets.Types;     use Sockets.Types;
 with Sockets.Utils;     use Sockets.Utils;
+
+pragma Elaborate_All (Sockets);
 
 package body Sockets.Multicast is
 

--- a/src/sockets-utils.adb
+++ b/src/sockets-utils.adb
@@ -123,13 +123,6 @@ package body Sockets.Utils is
       else
          Raise_Exception (Socket_Error'Identity, Message);
       end if;
-
-      --  The following line works around a bug in GNAT that does not
-      --  recognize Ada.Exceptions.Raise_Exception as raising an exception,
-      --  even if it can compute statically that the occurrence cannot
-      --  be Null_Occurrence ???
-
-      raise Program_Error;
    end Raise_With_Message;
 
 end Sockets.Utils;


### PR DESCRIPTION
- No need to use the parent commit, even when calling a pragma on it
- GNAT now recognize Ada.Exceptions.Raise_Exception properly
